### PR TITLE
feat: add py templates

### DIFF
--- a/scripts-ts/templates-py/module/model.py.tpl
+++ b/scripts-ts/templates-py/module/model.py.tpl
@@ -1,0 +1,22 @@
+# {{MODULE_NAME}}: MODEL
+from datetime import datetime
+import uuid
+
+from sqlalchemy import Column, DateTime
+from sqlalchemy.dialects.postgresql import UUID  # use sqlalchemy_utils if you prefer
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()  # or import your own shared Base
+
+class {{MODULE_NAME_UPPER}}(Base):
+    __tablename__ = "{{MODULE_NAME}}"
+
+    id         = Column(UUID(as_uuid=True), primary_key=True,
+                        default=uuid.uuid4, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow,
+                        onupdate=datetime.utcnow, nullable=False)
+
+    # Optional—for nicer logging
+    def __repr__(self) -> str:                       # pragma: no cover
+        return f"<{{MODULE_NAME_UPPER}} id={self.id}>"

--- a/scripts-ts/templates-py/module/repository.py.tpl
+++ b/scripts-ts/templates-py/module/repository.py.tpl
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from .model import {{MODULE_NAME_UPPER}}
 
 class Repository:
-    """Thin SQLAlchemy wrapper that mirrors the Go gormRepo API."""
+    """Thin SQLAlchemy wrapper."""
 
     def __init__(self, db: Session) -> None:
         self.db = db

--- a/scripts-ts/templates-py/module/repository.py.tpl
+++ b/scripts-ts/templates-py/module/repository.py.tpl
@@ -1,0 +1,42 @@
+# {{MODULE_NAME}}: REPOSITORY
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from .model import {{MODULE_NAME_UPPER}}
+
+class Repository:
+    """Thin SQLAlchemy wrapper that mirrors the Go gormRepo API."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    # CRUD -------------------------------------------------------------
+    def create(self, m: {{MODULE_NAME_UPPER}}) -> {{MODULE_NAME_UPPER}}:
+        self.db.add(m)
+        self.db.commit()
+        self.db.refresh(m)
+        return m
+
+    def find_by_id(self, id: UUID) -> Optional[{{MODULE_NAME_UPPER}}]:
+        return (
+            self.db
+            .query({{MODULE_NAME_UPPER}})
+            .filter({{MODULE_NAME_UPPER}}.id == id)
+            .first()
+        )
+
+    def list(self) -> List[{{MODULE_NAME_UPPER}}]:
+        return self.db.query({{MODULE_NAME_UPPER}}).all()
+
+    def update(self, m: {{MODULE_NAME_UPPER}}) -> {{MODULE_NAME_UPPER}}:
+        self.db.commit()
+        self.db.refresh(m)
+        return m
+
+    def delete(self, id: UUID) -> None:
+        obj = self.find_by_id(id)
+        if obj:
+            self.db.delete(obj)
+            self.db.commit()

--- a/scripts-ts/templates-py/module/service.py.tpl
+++ b/scripts-ts/templates-py/module/service.py.tpl
@@ -1,0 +1,27 @@
+# {{MODULE_NAME}}: SERVICE logic
+from typing import List
+from uuid import UUID
+
+from .repository import Repository
+from .model import {{MODULE_NAME_UPPER}}
+
+class Service:
+    """Business‑logic layer; stays persistence‑agnostic."""
+
+    def __init__(self, repo: Repository) -> None:
+        self.repo = repo
+
+    def create(self, m: {{MODULE_NAME_UPPER}}) -> {{MODULE_NAME_UPPER}}:
+        return self.repo.create(m)
+
+    def find_by_id(self, id: UUID) -> {{MODULE_NAME_UPPER}} | None:
+        return self.repo.find_by_id(id)
+
+    def list(self) -> List[{{MODULE_NAME_UPPER}}]:
+        return self.repo.list()
+
+    def update(self, m: {{MODULE_NAME_UPPER}}) -> {{MODULE_NAME_UPPER}}:
+        return self.repo.update(m)
+
+    def delete(self, id: UUID) -> None:
+        self.repo.delete(id)

--- a/scripts-ts/templates-py/module/use-cases.py.tpl
+++ b/scripts-ts/templates-py/module/use-cases.py.tpl
@@ -1,0 +1,106 @@
+# {{MODULE_NAME}}: USE CASES (HTTP transport layer)
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field, UUID4
+from sqlalchemy.orm import Session
+
+from .service import Service
+from .repository import Repository
+from .model import {{MODULE_NAME_UPPER}}
+from .database import get_db  # ← supply a Session‑scoped dependency
+
+router = APIRouter(prefix="/{{MODULE_NAME}}", tags=["{{MODULE_NAME}}"])
+
+# -------------------------- DTOs / Schemas ---------------------------
+class Create{{MODULE_NAME_UPPER}}Req(BaseModel):
+    # TODO: add fields for creation, e.g. name: str = Field(...)
+    pass
+
+class ErrorResponse(BaseModel):
+    error: str
+
+# -------------------------- Dependencies -----------------------------
+def get_service(db: Session = Depends(get_db)) -> Service:
+    return Service(Repository(db))
+
+# --------------------------- Handlers --------------------------------
+@router.post(
+    "",
+    response_model={{MODULE_NAME_UPPER}},
+    status_code=status.HTTP_201_CREATED,
+    responses={400: {"model": ErrorResponse},
+               500: {"model": ErrorResponse}},
+)
+def create(
+    req: Create{{MODULE_NAME_UPPER}}Req,
+    service: Service = Depends(get_service),
+):
+    model = {{MODULE_NAME_UPPER}}(**req.dict())  # map DTO → ORM
+    try:
+        return service.create(model)
+    except Exception as e:  # noqa: BLE001
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.get(
+    "/{id}",
+    response_model={{MODULE_NAME_UPPER}},
+    responses={404: {"model": ErrorResponse}},
+)
+def get(
+    id: UUID4,
+    service: Service = Depends(get_service),
+):
+    model = service.find_by_id(UUID(str(id)))
+    if model is None:
+        raise HTTPException(status_code=404, detail="not found")
+    return model
+
+
+@router.get(
+    "",
+    response_model=List[{{MODULE_NAME_UPPER}}],
+)
+def list(
+    service: Service = Depends(get_service),
+):
+    return service.list()
+
+
+@router.put(
+    "/{id}",
+    response_model={{MODULE_NAME_UPPER}},
+)
+def update(
+    id: UUID4,
+    req: Create{{MODULE_NAME_UPPER}}Req,  # replace with dedicated Update DTO if needed
+    service: Service = Depends(get_service),
+):
+    model = service.find_by_id(UUID(str(id)))
+    if model is None:
+        raise HTTPException(status_code=404, detail="not found")
+
+    # partial update – copy only provided fields
+    for field, value in req.dict(exclude_unset=True).items():
+        setattr(model, field, value)
+
+    try:
+        return service.update(model)
+    except Exception as e:  # noqa: BLE001
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.delete(
+    "/{id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def delete(
+    id: UUID4,
+    service: Service = Depends(get_service),
+):
+    try:
+        service.delete(UUID(str(id)))
+    except Exception as e:  # noqa: BLE001
+        raise HTTPException(status_code=500, detail=str(e)) from e

--- a/scripts-ts/templates-py/service/.dockerignore.tpl
+++ b/scripts-ts/templates-py/service/.dockerignore.tpl
@@ -1,0 +1,11 @@
+# {{SERVICE_NAME}}: .dockerignore
+__pycache__/
+*.py[cod]
+*.egg-info/
+*.log
+.env
+.git
+.gitignore
+.vscode/
+.idea/
+tests/

--- a/scripts-ts/templates-py/service/.env.tpl
+++ b/scripts-ts/templates-py/service/.env.tpl
@@ -1,0 +1,10 @@
+# {{SERVICE_NAME}}/.env.tpl
+# ──────── Database ────────
+DB_HOST=localhost
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_NAME={{SERVICE_NAME}}
+DB_PORT=5432
+
+# ──────── App ─────────────
+APP_PORT=8080

--- a/scripts-ts/templates-py/service/Dockerfile.tpl
+++ b/scripts-ts/templates-py/service/Dockerfile.tpl
@@ -1,0 +1,40 @@
+# {{SERVICE_NAME}}: Dockerfile (multi‑stage)
+
+# ───── Build image ─────────────────────────────────────────────────────────────
+FROM python:3.12-slim AS build
+
+WORKDIR /app
+
+# Install runtime deps first so they’re cached
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends gcc libpq-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# Poetry? Pip? We’ll stay with requirements.txt to match earlier template
+COPY requirements.txt ./
+RUN pip install --upgrade pip \
+ && pip install --no-cache-dir -r requirements.txt
+
+# ───── Production image ────────────────────────────────────────────────────────
+FROM python:3.12-slim
+
+# Add a non‑root user
+RUN addgroup --system app && adduser --system --ingroup app app
+USER app
+
+ENV PYTHONUNBUFFERED=1 \
+    # honour $APP_PORT from .env
+    APP_PORT=${APP_PORT:-8080}
+
+WORKDIR /app
+
+# Copy installed site‑packages from the build stage
+COPY --from=build /usr/local/lib/python*/site-packages /usr/local/lib/python*/site-packages
+COPY --from=build /usr/local/bin /usr/local/bin
+
+# Copy service source
+COPY --chown=app:app . .
+
+EXPOSE 8080
+
+CMD ["uvicorn", "internal.cmd.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/scripts-ts/templates-py/service/config.py.tpl
+++ b/scripts-ts/templates-py/service/config.py.tpl
@@ -1,0 +1,52 @@
+# {{SERVICE_NAME}}/internal/config/config.py.tpl
+"""Application and DB configuration loader (dotenv‑friendly)."""
+from dataclasses import dataclass
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# ────────────────────────────────────────────────────────────────────────────────
+# .env loading
+load_dotenv(dotenv_path=Path(__file__).resolve().parent.parent.parent / ".env", override=False)
+
+# ────────────────────────────────────────────────────────────────────────────────
+@dataclass(slots=True, frozen=True)
+class DBConfig:
+    host:     str
+    user:     str
+    password: str
+    name:     str
+    port:     str = "5432"
+
+    @property
+    def dsn(self) -> str:
+        """Return a Postgres SQLAlchemy DSN string."""
+        return (
+            "postgresql+psycopg2://"
+            f"{self.user}:{self.password}@{self.host}:{self.port}/{self.name}"
+        )
+
+
+@dataclass(slots=True, frozen=True)
+class AppConfig:
+    port: str
+    db:   DBConfig
+
+
+def _getenv(key: str, default: str) -> str:        # small helper
+    return os.getenv(key, default)
+
+
+def load() -> AppConfig:
+    """Read environment variables and return an AppConfig instance."""
+    return AppConfig(
+        port=_getenv("APP_PORT", "8080"),
+        db=DBConfig(
+            host=_getenv("DB_HOST", "localhost"),
+            user=_getenv("DB_USER", "postgres"),
+            password=_getenv("DB_PASSWORD", "postgres"),
+            name=_getenv("DB_NAME", "{{SERVICE_NAME}}"),
+            port=_getenv("DB_PORT", "5432"),
+        ),
+    )

--- a/scripts-ts/templates-py/service/database.py.tpl
+++ b/scripts-ts/templates-py/service/database.py.tpl
@@ -1,0 +1,38 @@
+# {{SERVICE_NAME}}/internal/database.py.tpl
+"""Engine, session factory and FastAPI dependency."""
+
+from contextlib import contextmanager
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
+
+from .config.config import load
+
+_cfg = load()
+
+# Engine – echo=True for local debugging
+engine = create_engine(_cfg.db.dsn, pool_pre_ping=True, echo=False, future=True)
+
+# sessionmaker returns an "autocommit=False / autoflush=False" Session class – typical FastAPI recipe
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+
+
+@contextmanager
+def session_scope() -> Generator[Session, None, None]:
+    """Provide a transactional scope around a series of operations."""
+    session: Session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except:   # noqa: E722 – re‑raise after rollback
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+# FastAPI dependency used earlier in `use_cases.py.tpl`
+def get_db() -> Generator[Session, None, None]:
+    with session_scope() as db:
+        yield db

--- a/scripts-ts/templates-py/service/docker-compose.yml.tpl
+++ b/scripts-ts/templates-py/service/docker-compose.yml.tpl
@@ -1,0 +1,38 @@
+# {{SERVICE_NAME}}: docker‑compose
+services:
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=${DB_USER:-postgres}
+      - POSTGRES_PASSWORD=${DB_PASSWORD:-postgres}
+      - POSTGRES_DB=${DB_NAME:-{{SERVICE_NAME}}}
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  {{SERVICE_NAME}}:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - .env               # Re‑use same env you use locally
+    environment:
+      # Override DB_HOST so the app connects to *container* “db”
+      - DB_HOST=db
+      # FastAPI will still honour APP_PORT coming from .env
+    ports:
+      - "${APP_PORT:-8080}:8080"
+    restart: unless-stopped
+
+volumes:
+  db_data:

--- a/scripts-ts/templates-py/service/main.py.tpl
+++ b/scripts-ts/templates-py/service/main.py.tpl
@@ -1,6 +1,6 @@
 # {{SERVICE_NAME}}/cmd/main.py.tpl
 """
-Entry‑point matching Go's main.go:
+Entry‑point:
 
 * Boots FastAPI
 * Connects DB

--- a/scripts-ts/templates-py/service/main.py.tpl
+++ b/scripts-ts/templates-py/service/main.py.tpl
@@ -1,0 +1,71 @@
+# {{SERVICE_NAME}}/cmd/main.py.tpl
+"""
+Entry‑point matching Go's main.go:
+
+* Boots FastAPI
+* Connects DB
+* Auto‑migrates metadata in dev
+* Mounts Swagger (FastAPI serves it at /docs & /redoc automatically)
+"""
+import logging
+import uvicorn
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from internal.config.config import load
+from internal.database import engine
+from internal.{{MODULE_NAME}}.model import Base as {{MODULE_NAME}}Base
+# IMPORT NEW MODULE MODELS HERE – keep this comment for code‑gen marker
+
+from internal.{{MODULE_NAME}}.use_cases import router as {{MODULE_NAME}}_router
+# REGISTER NEW MODULE ROUTERS HERE – keep this comment for code‑gen marker
+
+log = logging.getLogger("uvicorn.error")
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Settings & DB
+cfg = load()
+
+# Auto‑migrate: create tables if they don't exist (dev‑only)
+log.info("Running migrations (SQLAlchemy create_all)")
+{{MODULE_NAME}}Base.metadata.create_all(bind=engine)
+# ADD NEW MODULE metadata.create_all(...) HERE IF NECESSARY
+
+# ────────────────────────────────────────────────────────────────────────────────
+# FastAPI app
+app = FastAPI(
+    title="{{SERVICE_NAME}} API",
+    version="1.0",
+    description=f"This is a sample server for {{SERVICE_NAME}}.",
+    docs_url="/swagger/docs",
+    redoc_url="/swagger/redoc",
+    openapi_url="/swagger/openapi.json",
+)
+
+# CORS example (customise/remove)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Health‑check
+@app.get("/ping")
+def ping() -> dict[str, str]:
+    return {"message": "pong"}
+
+# Routers (end‑points)
+app.include_router({{MODULE_NAME}}_router)
+# AUTO‑INCLUDE NEW ROUTERS ABOVE THIS LINE
+
+# ────────────────────────────────────────────────────────────────────────────────
+if __name__ == "__main__":
+    log.info("🌱 listening on :%s", cfg.port)
+    uvicorn.run(
+        "internal.cmd.main:app",
+        host="0.0.0.0",
+        port=int(cfg.port),
+        reload=True,          # hot‑reload in dev
+        log_level="info",
+    )

--- a/scripts-ts/templates-py/service/requirements.txt.tpl
+++ b/scripts-ts/templates-py/service/requirements.txt.tpl
@@ -1,0 +1,6 @@
+fastapi
+uvicorn[standard]
+sqlalchemy>=2.0
+psycopg2-binary
+python-dotenv
+pydantic


### PR DESCRIPTION
## 🚀 Add Python FastAPI service scaffold & Docker runtime

### Summary

A complete, parameterised template set for building and running a Python micro‑service is now available. After code‑generation, a single `docker compose up --build` launches:

* **PostgreSQL** (with health‑check and persisted volume)
* **FastAPI service** (Swagger at `/swagger/docs`, auto‑creates tables on start)

### Added

* **Service layer templates** – `model.py.tpl`, `repository.py.tpl`, `service.py.tpl`, `use_cases.py.tpl`
* **Infrastructure** – `config.py.tpl`, `.env.tpl`, `database.py.tpl`, `main.py.tpl`
* **Containerisation** – `Dockerfile.tpl`, `docker-compose.yml.tpl`, `.dockerignore.tpl`
* **Dependencies** – `requirements.txt.tpl` (FastAPI, SQLAlchemy, psycopg2‑binary, python‑dotenv)

### TODO

* [ ] Integrate **Alembic** for version‑controlled DB migrations
* [ ] Execute an end‑to‑end run to verify the service boots and responds correctly
